### PR TITLE
Fix issue with get calls caused by latest swagger client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.activities.getActivities(arguments[0], this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.activities.getActivities(arguments[0], this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -172,7 +172,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.abactivity.getABActivity(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.abactivity.getABActivity(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -196,7 +196,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.xtactivity.getXTActivity(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.xtactivity.getXTActivity(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -433,7 +433,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.activity.getChangeLog(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.activity.getChangeLog(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -457,7 +457,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.offers.getOffers(arguments[0], this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V2)))
+      this.sdk.apis.offers.getOffers(arguments[0], this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V2)))
         .then(response => {
           resolve(response)
         })
@@ -481,7 +481,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.offer.getOfferById(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V2)))
+      this.sdk.apis.offer.getOfferById(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V2)))
         .then(response => {
           resolve(response)
         })
@@ -577,7 +577,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.audiences.getAudiences(arguments[0], this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.audiences.getAudiences(arguments[0], this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -623,7 +623,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.audiences.getAudienceById(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.audiences.getAudienceById(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -693,7 +693,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.properties.getProperties({}, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.properties.getProperties({}, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -717,7 +717,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.properties.getAPropertyById(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.properties.getAPropertyById(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -738,7 +738,7 @@ class TargetCoreAPI {
     const sdkDetails = {}
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.mboxes.getMBoxes({}, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.mboxes.getMBoxes({}, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -762,7 +762,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.mboxes.getMBoxByName(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.mboxes.getMBoxByName(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -783,7 +783,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.mbox.getProfileAttributes({}, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.mbox.getProfileAttributes({}, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -804,7 +804,7 @@ class TargetCoreAPI {
     const sdkDetails = options
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.environments.getEnvironments({}, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
+      this.sdk.apis.environments.getEnvironments({}, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V1)))
         .then(response => {
           resolve(response)
         })
@@ -828,7 +828,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.reports.getABPerformance(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.reports.getABPerformance(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -852,7 +852,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.reports.getXTPerformance(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.reports.getXTPerformance(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -876,7 +876,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.reports.getABTPerformance(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.reports.getABTPerformance(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })
@@ -900,7 +900,7 @@ class TargetCoreAPI {
     const sdkDetails = params
     const headers = options.headers ? options.headers : {}
     return new Promise((resolve, reject) => {
-      this.sdk.apis.reports.getAuditReport(params, this.__createRequest({}, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
+      this.sdk.apis.reports.getAuditReport(params, this.__createRequest(null, headers, this.__getAcceptHeader(ACCEPT_HEADERS.V3)))
         .then(response => {
           resolve(response)
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #52 
With new swagger client 3.10.2 get calls were failing for empty body. Fixed this.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests and e2e test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
