### PR TITLE
Revert "fix: swagger-client's dependency was using a node-15+ class AggregateError. we polyfill it (#78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@adobe/aio-lib-core-errors": "^3.1.0",
     "@adobe/aio-lib-core-logging": "^2.0.0",
-    "es-aggregate-error": "^1.0.10",
     "swagger-client": "^3.19.10"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,6 @@ governing permissions and limitations under the License.
 
 'use strict'
 
-// polyfill for node < 15
-const AggregateError = require('es-aggregate-error')
-AggregateError.shim() // noop if not needed
-
 const Swagger = require('swagger-client')
 const { codes } = require('./SDKErrors')
 const logger = require('@adobe/aio-lib-core-logging')('aio-lib-target', { level: process.env.LOG_LEVEL })


### PR DESCRIPTION
This reverts commit 5ce3077469b03e1e680b7cfb7bfcf715f4025293.

## Description

[swagger-api/apidom](https://github.com/swagger-api/apidom/releases/tag/v0.76.1) released a fix including this polyfill in https://github.com/swagger-api/apidom/releases/tag/v0.76.1, which will be picked up in this lib by the new release of swagger-client https://github.com/swagger-api/swagger-js/releases/tag/v3.20.1, so we no longer need this

## Related Issue

https://github.com/swagger-api/swagger-js/issues/3127

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

See the test in https://github.com/adobe/aio-lib-target/issues/77

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
